### PR TITLE
Expose the package name in an environment variable so custom build scripts can use it

### DIFF
--- a/o3de_package_scripts/build_package.py
+++ b/o3de_package_scripts/build_package.py
@@ -52,11 +52,12 @@ def BuildPackage(package_name, output_folder, search_path):
 
         # Put the package_name in an environment variable so that the build script
         # can reference it if desired
-        os.environ["O3DE_PACKAGE_NAME"] = package_name
+        subprocess_env = os.environ.copy()
+        subprocess_env["O3DE_PACKAGE_NAME"] = package_name
 
         print(f"Calling build script: \"{build_script_cmd}\"...")
         cmd = [sys.executable, '-s', build_script_path] + build_script_cmd.split(' ')[1:]
-        output = subprocess.run(cmd, cwd=build_script_folder)
+        output = subprocess.run(cmd, cwd=build_script_folder, env=subprocess_env)
         if output.returncode != 0:
             print(f"Package {package_name} failed to build from source.")
             return 1

--- a/o3de_package_scripts/build_package.py
+++ b/o3de_package_scripts/build_package.py
@@ -49,7 +49,11 @@ def BuildPackage(package_name, output_folder, search_path):
         if package_name not in folder_packages:
             print(f"Error: {package_name} specified in the source packages, but not the folder packages!")
             return 1
-            
+
+        # Put the package_name in an environment variable so that the build script
+        # can reference it if desired
+        os.environ["O3DE_PACKAGE_NAME"] = package_name
+
         print(f"Calling build script: \"{build_script_cmd}\"...")
         cmd = [sys.executable, '-s', build_script_path] + build_script_cmd.split(' ')[1:]
         output = subprocess.run(cmd, cwd=build_script_folder)


### PR DESCRIPTION
Exposed the package name in an `O3DE_PACKAGE_NAME` environment variable so that any custom build script can consume it. The use case I uncovered was the build script for OpenImageIO generates the `PackageInfo.json` dynamically, so it is useful to be able to pull the package name from a variable rather than having it duplicated in the build script.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>