### PR TITLE
Support for Linux aarch64 (ARM64) for 3P scripts

### DIFF
--- a/o3de_package_scripts/common.py
+++ b/o3de_package_scripts/common.py
@@ -69,6 +69,13 @@ class CommonUtils():
         ''' Returns 'darwin', 'linux', or 'windows'
         '''
         platsys = platform.system().lower()
+        # If the current platform is linux, add the architecture to the platform name as well
+        if platsys == 'linux':
+            if platform.machine() == 'aarch64':
+                return f'{platsys}-{platform.machine()}'
+            # For x86_64 and others, default to the legacy 'linux' as the PAL platform name
+            return platsys
+
         return platsys
 
     @staticmethod


### PR DESCRIPTION
Update to add the architecture to the platform name for special case of linux to support aarch64.

