### PR TITLE
Rename 'aarch64' result to 'arm64' for PAL Platform Name

### DIFF
--- a/o3de_package_scripts/common.py
+++ b/o3de_package_scripts/common.py
@@ -72,7 +72,7 @@ class CommonUtils():
         # If the current platform is linux, add the architecture to the platform name as well
         if platsys == 'linux':
             if platform.machine() == 'aarch64':
-                return f'{platsys}-{platform.machine()}'
+                return f'{platsys}-arm64'
             # For x86_64 and others, default to the legacy 'linux' as the PAL platform name
             return platsys
 


### PR DESCRIPTION
Rename 'aarch64' result from platform.machine() to 'arm64' for PAL consistency

Signed-off-by: Steve Pham <82231385+spham-amzn@users.noreply.github.com>