### PR TITLE
Support for Mac Arm64 (Apple Silicon)

### DIFF
--- a/o3de_package_scripts/common.py
+++ b/o3de_package_scripts/common.py
@@ -75,6 +75,9 @@ class CommonUtils():
                 return f'{platsys}-{platform.machine()}'
             # For x86_64 and others, default to the legacy 'linux' as the PAL platform name
             return platsys
+        elif platsys == 'darwin':
+            if platform.machine() == 'arm64':
+                return f'{platsys}-{platform.machine()}'
 
         return platsys
 


### PR DESCRIPTION
Add check for architecture to select the arm variant for mac